### PR TITLE
Add firewalld support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Tallow attaches to the journal and subscribes to messages from
 /usr/sbin/sshd. The messages are matched against rules and the IP
 address is extracted from the message.  For each IP address that is
 extracted, the last timestamp and count is kept. Once the count exceeds
-a threshold, iptables is executed to set a IP-based blocking rule.
+a threshold, the offending IP address is added to an ipset and blocked 
+with a corresponding firewall rule. It will use firewalld or 
+iptables / ip6tables.
 
 The timestamp is kept for pruning. Records are pruned from the list
 if the IP address hasn't been seen by tallow for longer than the

--- a/man/tallow.conf.5.md
+++ b/man/tallow.conf.5.md
@@ -61,11 +61,11 @@ before tallow starts up and remove them afterwards. To create them
 manually, you can use the following commands:
 
   ```
-  iptables -t filter -I INPUT 1 -m set --match-set tallow src -j DROP
   ipset create tallow hash:ip family inet timeout 3600
+  iptables -t filter -I INPUT 1 -m set --match-set tallow src -j DROP
 
-  ip6tables -t filter -I INPUT 1 -m set --match-set tallow6 src -j DROP
   ipset create tallow6 hash:ip family inet6 timeout 3600
+  ip6tables -t filter -I INPUT 1 -m set --match-set tallow6 src -j DROP
   ```
 
 ## SEE ALSO

--- a/man/tallow.conf.5.md
+++ b/man/tallow.conf.5.md
@@ -20,8 +20,9 @@ tallow will operate with built-in defaults.
 ## OPTIONS
 
 `ipt_path`=`<string>`
-Specifies the location of the ipset(1), iptables(1) or ip6tables(1)
-program. By default, tallow will look in "/usr/sbin" for them.
+Specifies the location of the ipset(1) program and iptables(1), 
+ip6tables(1), or firewall-cmd(1) programs. By default, tallow will 
+look in "/usr/sbin" for them.
 
 `expires`=`<int>`
 The number of seconds that IP addresses are blocked for. Note that
@@ -52,13 +53,14 @@ disable ipv6 support if your system does not have ipv6 or is
 missing ip6tables. Even with ipv6 disabled, tallow will track
 and log ipv6 addresses.
 
-`nocreate`=`<0|1>`
-Disable the creation of iptables rules and ipset sets. By default,
-tallow will create new iptables(1) and ip6tables(1) rules when needed
-automatically. If set to `1`, `tallow(1)` will not create any new
-iptables rules or ipset sets to work. You should create them manually
-before tallow starts up and remove them afterwards. To create them
-manually, you can use the following commands:
+`nocreate`=`<0|1>` Disable the creation of firewall rules and ipset sets. By
+default, tallow will create new firewall-cmd(1) or iptables(1) and ip6tables(1)
+rules when needed automatically. If set to `1`, `tallow(1)` will not create any
+new firewall DROP rules or ipset sets that are needed work. You should create
+them manually before tallow starts up and remove them afterwards using the sets
+of commands below. 
+
+Use the following commands if you're using iptables(1):
 
   ```
   ipset create tallow hash:ip family inet timeout 3600
@@ -68,6 +70,17 @@ manually, you can use the following commands:
   ip6tables -t filter -I INPUT 1 -m set --match-set tallow6 src -j DROP
   ```
 
+Use the following commands if you're using firewalld(1):
+
+```
+  firewall-cmd --permanent --new-ipset=tallow --type=hash:ip --family=inet --option=timeout=3600
+  firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT 1 -m set --match-set tallow src -j DROP
+  
+  firewall-cmd --permanent --new-ipset=tallow6 --type=hash:ip --family=inet6 --option=timeout=3600
+  firewall-cmd --permanent --direct --add-rule ipv6 filter INPUT 1 -m set --match-set tallow6 src -j DROP
+  
+  ```
+
 ## SEE ALSO
 
 tallow(1)
@@ -75,4 +88,3 @@ tallow(1)
 ## AUTHOR
 
 Auke Kok <auke-jan.h.kok@intel.com>
-


### PR DESCRIPTION
To PR is an attempt at adding firewall support for tallow and updates documentation accordingly.

It uses firewalld if it determined to be running, otherwise it continues to use iptables as normal. 

Note: The `firewall-cmd` commands use the [direct interface](https://firewalld.org/documentation/direct/options.html). I think this is okay for tallow and makes sense because the syntax closely mimics the syntax from iptables. 

Firewalld recommends using the zones (i.e. `firewall-cmd --permanent --zone=drop --add-source=ipset:tallow`):
> Direct configuration should be used only as a last resort when it’s not possible to use firewalld.zone(5).

However this resulted in a tricky situation when tallow defines the first zone rule (i.e out-of-box; the default 'public' zone is being used on the system and no explicit zone per-interface is set) then it becomes the only active zone dropping all traffic. This behavior would be unexpected to most users.


Closes https://github.com/clearlinux/tallow/issues/11
Related https://github.com/clearlinux/clear-linux-documentation/issues/541