### PR TITLE
Added second level headers to man page docs.

### DIFF
--- a/man/tallow.1.md
+++ b/man/tallow.1.md
@@ -5,11 +5,11 @@
 
 Reduce log clutter due to ssh login attempts.
 
-# SYNOPSIS
+## SYNOPSIS
 
 `/usr/sbin/tallow`
 
-# DESCRIPTION
+## DESCRIPTION
 
 `tallow` is a daemon that watches the systemd journal for messages
 from the `sshd` service. It parses the messages and looks for
@@ -37,22 +37,22 @@ blocked inadvertently. You may wish to list any valid IP address
 with the whitelist option in tallow.conf(5). Multiple addresses can
 be whitelisted.
 
-# OPTIONS
+## OPTIONS
 
 The `tallow` daemon itself has no runtime configuration. All
 configuration is done through the tallow.conf(5) config file.
 
-# SIGNALS
+## SIGNALS
 
 The `USR1` signal causes `tallow` to print out it's internal tracking
 table of IP addresses. This requires that tallow is compiled with
 the `-DDEBUG=1` symbol passed to the compiler.
 
-# SEE ALSO
+## SEE ALSO
 
 systemd-journald(1), iptables(1), ipset(1), tallow.conf(5), tallow.patterns(5)
 
-# BUGS
+## BUGS
 
 `tallow` is `NOT A SECURITY SOLUTION`, nor does it protect against
 random password logins. A attacker may still be able to logon to your

--- a/man/tallow.conf.5.md
+++ b/man/tallow.conf.5.md
@@ -5,21 +5,21 @@
 
 The tallow configuration file
 
-# NAME
+## NAME
 
 tallow.conf - Tallow daemon configuration file
 
-# SYNOPSIS
+## SYNOPSIS
 
 `/etc/tallow.conf`
 
-# DESCRIPTION
+## DESCRIPTION
 
 This file is read on startup by the tallow(1) daemon, and can
 be used to provide options to the tallow daemon. If not present,
 tallow will operate with built-in defaults.
 
-# OPTIONS
+## OPTIONS
 
 `fwcmd_path`=`<string>`
 Specifies the location of the ipset(1) firewall-cmd(1) programs. By
@@ -87,6 +87,6 @@ Use the following commands if you're using firewalld(1):
 
   ```
 
-# SEE ALSO
+## SEE ALSO
 
 tallow(1), tallow.patterns(5)

--- a/man/tallow.patterns.5.md
+++ b/man/tallow.patterns.5.md
@@ -6,7 +6,7 @@
 Tallow pattern matching configuration files.
 
 
-# SYNOPSIS
+## SYNOPSIS
 
 tallow(1) uses regular expressions to match journal entries and extract an IP
 address from them. JSON files are used to configure the patterns and banning
@@ -16,7 +16,7 @@ thresholds used by tallow(1).
 `/usr/share/tallow/*.json`
 
 
-# DESCRIPTION
+## DESCRIPTION
 
 tallow(1) uses regular expressions to match journal entries and extract an IP
 address from them. JSON files are used to configure the patterns and banning
@@ -31,7 +31,7 @@ files under `/etc/tallow`. The default JSON files can be overridden by creating
 the same file under `/etc/tallow`.
 
 
-# FILE FORMAT
+## FILE FORMAT
 
 Pattern configuration files use the JavaScript Object Notation (JSON) format.
 
@@ -61,7 +61,7 @@ object is an array containing objects with a `filter` key and an `items` key.
      See systemd.journal-fields(7) for valid journal fields.
 
 
-# EXAMPLES
+## EXAMPLES
 
 1. The JSON below is a snippet from one of the default pattern configuration
    files for blocking certain failed `sshd` connections.
@@ -122,12 +122,12 @@ object is an array containing objects with a `filter` key and an `items` key.
    ```
 
 
-# SEE ALSO
+## SEE ALSO
 
 tallow(1), tallow.conf(5)
 
 
-# BUGS
+## BUGS
 
 `tallow` is `NOT A SECURITY SOLUTION`, nor does it protect against random
 password logins. An attacker may still be able to logon to your systems if you


### PR DESCRIPTION
This improves integration with automated document publishing systems like Sphinx. Plan is to incorporate all man pages into Clear Linux Documentation site. 

Signed-off-by: Kevin Putnam <kevin.putnam@intel.com>